### PR TITLE
Feature/nodelet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_BUILD_TYPE Release)
 #############
 add_library(${PROJECT_NAME} src/odometry_transformer.cc
                             src/odometry_transformer_nodelet.cc)
-target_link_libraries(${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ############
 # Binaries #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin
   tf2_geometry_msgs
   tf2_ros geometry_msgs
   dynamic_reconfigure
+  nodelet
+  pluginlib
   )
 
 include_directories(include ${catkin_INCLUDE_DIRS})
@@ -26,7 +28,8 @@ set(CMAKE_BUILD_TYPE Release)
 #############
 # LIBRARIES #
 #############
-add_library(${PROJECT_NAME} src/odometry_transformer.cc)
+add_library(${PROJECT_NAME} src/odometry_transformer.cc
+                            src/odometry_transformer_nodelet.cc)
 target_link_libraries(${PROJECT_NAME})
 
 ############
@@ -46,4 +49,7 @@ install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(FILES nodelet_plugin.xml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/cfg/OdometryTransformer.cfg
+++ b/cfg/OdometryTransformer.cfg
@@ -10,7 +10,7 @@ gen.add("TS_pitch", double_t, 0, "Odometry source pitch offset from target frame
 gen.add("TS_yaw", double_t, 0, "Odometry source yaw offset from target frame.", 0.0)
 
 gen.add("T_r_TS_x", double_t, 0, "Odometry source x-offset in target frame.", 0.0)
-gen.add("T_r_TS_y", double_t, 0, "Odometry source x-offset in target frame.", 0.0)
-gen.add("T_r_TS_z", double_t, 0, "Odometry source x-offset in target frame.", 0.0)
+gen.add("T_r_TS_y", double_t, 0, "Odometry source y-offset in target frame.", 0.0)
+gen.add("T_r_TS_z", double_t, 0, "Odometry source z-offset in target frame.", 0.0)
 
 exit(gen.generate(PACKAGE, "odometry_transformer", "OdometryTransformer"))

--- a/nodelet_plugin.xml
+++ b/nodelet_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libodometry_transformer_nodelet">
+<library path="lib/libodometry_transformer">
     <class name="odometry_transformer/OdometryTransformerNodelet"
            type="odometry_transformer::OdometryTransformerNodelet"
            base_class_type="nodelet::Nodelet">

--- a/nodelet_plugin.xml
+++ b/nodelet_plugin.xml
@@ -1,0 +1,9 @@
+<library path="lib/libodometry_transformer_nodelet">
+    <class name="odometry_transformer/OdometryTransformerNodelet"
+           type="odometry_transformer::OdometryTransformerNodelet"
+           base_class_type="nodelet::Nodelet">
+        <description>
+            This nodelet transforms odometry between two coordinate frames on the same rigid body.
+        </description>
+    </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <build_depend>tf2_ros</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>pluginlib</build_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
@@ -25,5 +27,10 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
 
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugin.xml" />
+  </export>
 </package>

--- a/src/odometry_transformer.cc
+++ b/src/odometry_transformer.cc
@@ -132,7 +132,7 @@ void OdometryTransformer::initializeDynamicReconfigure() {
       odometry_transformer::OdometryTransformerConfig>::CallbackType f;
   f = std::bind(&OdometryTransformer::reconfigureOdometryTransformer, this,
                 std::placeholders::_1, std::placeholders::_2);
-  dyn_server_.emplace();
+  dyn_server_.emplace(nh_private_);
   dyn_server_->setCallback(f);
 }
 

--- a/src/odometry_transformer_nodelet.cc
+++ b/src/odometry_transformer_nodelet.cc
@@ -1,0 +1,26 @@
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+
+#include "odometry_transformer/odometry_transformer.h"
+
+namespace odometry_transformer {
+
+class OdometryTransformerNodelet : public nodelet::Nodelet {
+ private:
+  inline virtual void onInit() {
+    try {
+      tf_ = std::make_shared<OdometryTransformer>(getNodeHandle(),
+                                                  getPrivateNodeHandle());
+    } catch (std::runtime_error e) {
+      ROS_ERROR("%s", e.what());
+    }
+  }
+
+  std::shared_ptr<OdometryTransformer> tf_;
+};
+
+}
+
+PLUGINLIB_EXPORT_CLASS(odometry_transformer::OdometryTransformerNodelet,
+    nodelet::Nodelet
+)

--- a/test/launch/test_realsense_t265_nodelet.launch
+++ b/test/launch/test_realsense_t265_nodelet.launch
@@ -1,21 +1,65 @@
 <launch>
+    <!-- Nodelet specific parameters -->
+    <arg name="manager" default="nodelet_manager"/>
+
+    <!-- Array parameters -->
+    <arg name="q_TS" value="[0, 0.3826834, 0, 0.9238796]"/>
+    <arg name="T_r_TS" value="[1.0, 0.0, 0.0]"/>
+
     <node type="rviz" name="rviz" pkg="rviz"
           args="-d $(find odometry_transformer)/test/cfg/test_realsense_t265.rviz"/>
 
-    <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" cwd="node" output="screen"/>
-    <node pkg="nodelet" type="nodelet" name="odometry_transformer_nodelet" args="load odometry_transformer/OdometryTransformerNodelet nodelet_manager">
+    <group ns="camera">
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" cwd="node" output="screen"/>
+    <node pkg="nodelet" type="nodelet" name="odometry_transformer_nodelet" args="load odometry_transformer/OdometryTransformerNodelet $(arg manager)">
         <remap from="source_odometry" to="/camera/odom/sample"/>
         <remap from="target_odometry" to="/camera/odom_body/sample"/>
 
         <param name="source_frame" value="camera_pose_frame"/>
         <param name="target_frame" value="robot_body_frame"/>
 
-        <!--rosparam param="q_TS" subst_value="True">[0, 0.3826834, 0, 0.9238796]</rosparam>
-        <rosparam param="T_r_TS" subst_value="True">[1.0, 0.0, 0.0]</rosparam-->
+        <rosparam param="q_TS" subst_value="True">$(arg q_TS)</rosparam>
+        <rosparam param="T_r_TS" subst_value="True">$(arg T_r_TS)</rosparam>
 
         <param name="lookup_tf" value="false"/>
         <param name="queue_size" value="1"/>
-        <param name="tcp_no_delay" value="false"/>
+        <param name="tcp_no_delay" value="false"/> <!-- This is not necessary for nodelets! -->
     </node>
+    <!-- Realsense tracking module settings -->
+    <rosparam command="load" file="$(find odometry_transformer)/test/cfg/t265.yaml" />
+    <!-- Realsense nodelet -->
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+        <arg name="tf_prefix"                value="camera"/>
+        <arg name="serial_no"                value=""/>
+        <arg name="usb_port_id"              value=""/>
+        <arg name="device_type"              value="t265"/>
+        <arg name="json_file_path"           value=""/>
+
+        <arg name="enable_sync"              value="false"/>
+
+        <arg name="fisheye_width"            value="-1"/>
+        <arg name="fisheye_height"           value="-1"/>
+        <arg name="enable_fisheye1"          value="false"/>
+        <arg name="enable_fisheye2"          value="false"/>
+
+        <arg name="fisheye_fps"              value="-1"/>
+        <arg name="gyro_fps"                 value="-1"/>
+        <arg name="accel_fps"                value="-1"/>
+        <arg name="enable_gyro"              value="true"/>
+        <arg name="enable_accel"             value="true"/>
+        <arg name="enable_pose"              value="true"/>
+
+        <arg name="linear_accel_cov"         value="0.01"/>
+        <arg name="initial_reset"            value="true"/>
+        <arg name="reconnect_timeout"        value="5.0"/>
+        <arg name="unite_imu_method"         value=""/>
+
+        <arg name="publish_odom_tf"          value="true"/>
+
+        <!-- Nodelet specific settings -->
+        <arg name="external_manager"         value="true"/>
+        <arg name="manager"                  value="$(arg manager)"/>
+    </include>
+    </group>
 
 </launch>

--- a/test/launch/test_realsense_t265_nodelet.launch
+++ b/test/launch/test_realsense_t265_nodelet.launch
@@ -1,0 +1,21 @@
+<launch>
+    <node type="rviz" name="rviz" pkg="rviz"
+          args="-d $(find odometry_transformer)/test/cfg/test_realsense_t265.rviz"/>
+
+    <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" cwd="node" output="screen"/>
+    <node pkg="nodelet" type="nodelet" name="odometry_transformer_nodelet" args="load odometry_transformer/OdometryTransformerNodelet nodelet_manager">
+        <remap from="source_odometry" to="/camera/odom/sample"/>
+        <remap from="target_odometry" to="/camera/odom_body/sample"/>
+
+        <param name="source_frame" value="camera_pose_frame"/>
+        <param name="target_frame" value="robot_body_frame"/>
+
+        <!--rosparam param="q_TS" subst_value="True">[0, 0.3826834, 0, 0.9238796]</rosparam>
+        <rosparam param="T_r_TS" subst_value="True">[1.0, 0.0, 0.0]</rosparam-->
+
+        <param name="lookup_tf" value="false"/>
+        <param name="queue_size" value="1"/>
+        <param name="tcp_no_delay" value="false"/>
+    </node>
+
+</launch>


### PR DESCRIPTION
This PR introduces a nodelet implementation for the odometry transformer. Thus you do not have to use tcp_no_delay to process high rate odometry messages.

![Screenshot from 2022-06-01 12-22-40](https://user-images.githubusercontent.com/11293852/171383215-b0bc906e-b7d4-4e09-8bdf-d456c95dc1ee.png)
