### PR TITLE
Pluginlib include .hpp instead of .h

### DIFF
--- a/launch/odometry_transformer.launch
+++ b/launch/odometry_transformer.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
   <!-- The original odometry source topic -->
   <arg name="source_odometry" default="source_odometry"/>

--- a/src/odometry_transformer_nodelet.cc
+++ b/src/odometry_transformer_nodelet.cc
@@ -1,5 +1,5 @@
 #include <nodelet/nodelet.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include "odometry_transformer/odometry_transformer.h"
 

--- a/src/odometry_transformer_nodelet.cc
+++ b/src/odometry_transformer_nodelet.cc
@@ -11,7 +11,7 @@ class OdometryTransformerNodelet : public nodelet::Nodelet {
     try {
       tf_ = std::make_shared<OdometryTransformer>(getNodeHandle(),
                                                   getPrivateNodeHandle());
-    } catch (std::runtime_error e) {
+    } catch (const std::runtime_error& e) {
       ROS_ERROR("%s", e.what());
     }
   }


### PR DESCRIPTION
The .h header has been deprecated for a long time so switching over to hpp won't break compatibility for many ros versions back.

I got a warning about the exception pass-by-value so changed that, and also added the xml header to the launch file as my text editor (vim) uses that for syntax highlighting.